### PR TITLE
Controller 슬라이스 테스트 추가

### DIFF
--- a/src/test/java/com/hyuns/cafit/presentation/CommonControllerSliceTestSupport.java
+++ b/src/test/java/com/hyuns/cafit/presentation/CommonControllerSliceTestSupport.java
@@ -1,0 +1,68 @@
+package com.hyuns.cafit.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyuns.cafit.context.ResetMockTestExecutionListener;
+import com.hyuns.cafit.domain.user.User;
+import com.hyuns.cafit.domain.user.repository.UserRepository;
+import com.hyuns.cafit.global.config.SecurityConfig;
+import com.hyuns.cafit.global.security.LoginUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+
+@ActiveProfiles("test")
+@Import({LoginUserArgumentResolver.class, SecurityConfig.class})
+@TestExecutionListeners(
+    value = ResetMockTestExecutionListener.class,
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
+)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public abstract class CommonControllerSliceTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected UserRepository userRepository;
+
+    protected static final long TEST_USER_ID = 1L;
+
+    @BeforeEach
+    void setUpLoginUser() {
+        User testUser = createTestUser();
+        given(userRepository.findById(TEST_USER_ID))
+            .willReturn(Optional.of(testUser));
+    }
+
+    protected MockHttpSession loginSession() {
+        return loginSession(TEST_USER_ID);
+    }
+
+    protected MockHttpSession loginSession(long userId) {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("userId", userId);
+        return session;
+    }
+
+    private User createTestUser() {
+        User user = new User("test@example.com", "encodedPassword", "테스트유저");
+        ReflectionTestUtils.setField(user, "id", TEST_USER_ID);
+        return user;
+    }
+}

--- a/src/test/java/com/hyuns/cafit/presentation/auth/AuthControllerTest.java
+++ b/src/test/java/com/hyuns/cafit/presentation/auth/AuthControllerTest.java
@@ -1,0 +1,120 @@
+package com.hyuns.cafit.presentation.auth;
+
+import com.hyuns.cafit.application.auth.AuthService;
+import com.hyuns.cafit.application.auth.dto.AuthResponse;
+import com.hyuns.cafit.application.auth.dto.LoginRequest;
+import com.hyuns.cafit.application.auth.dto.SignUpRequest;
+import com.hyuns.cafit.presentation.CommonControllerSliceTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class)
+class AuthControllerTest extends CommonControllerSliceTestSupport {
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void 회원가입_성공시_200을_반환한다() throws Exception {
+        // given
+        SignUpRequest request = new SignUpRequest("user@example.com", "password1234", "홍길동");
+        AuthResponse response = new AuthResponse(1L, "user@example.com", "홍길동");
+        given(authService.signup(any(SignUpRequest.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value(1L))
+            .andExpect(jsonPath("$.email").value("user@example.com"))
+            .andExpect(jsonPath("$.name").value("홍길동"));
+    }
+
+    @Test
+    void 회원가입시_이메일_형식이_잘못되면_400을_반환한다() throws Exception {
+        // given
+        SignUpRequest request = new SignUpRequest("invalid-email", "password1234", "홍길동");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 회원가입시_비밀번호가_4자_미만이면_400을_반환한다() throws Exception {
+        // given
+        SignUpRequest request = new SignUpRequest("user@example.com", "ab", "홍길동");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 로그인_성공시_200을_반환한다() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("user@example.com", "password1234");
+        AuthResponse response = new AuthResponse(1L, "user@example.com", "홍길동");
+        given(authService.login(any(LoginRequest.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value(1L))
+            .andExpect(jsonPath("$.email").value("user@example.com"));
+    }
+
+    @Test
+    void 로그인시_이메일이_비어있으면_400을_반환한다() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("", "password1234");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 로그아웃_성공시_200을_반환한다() throws Exception {
+        // when & then
+        mockMvc.perform(post("/api/auth/logout")
+                .session(loginSession()))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void 현재_사용자_조회시_200을_반환한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/auth/me")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value(TEST_USER_ID))
+            .andExpect(jsonPath("$.email").value("test@example.com"))
+            .andExpect(jsonPath("$.name").value("테스트유저"));
+    }
+
+    @Test
+    void 현재_사용자_조회시_세션이_없으면_401을_반환한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/auth/me"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/hyuns/cafit/presentation/beverage/BeverageControllerTest.java
+++ b/src/test/java/com/hyuns/cafit/presentation/beverage/BeverageControllerTest.java
@@ -1,0 +1,73 @@
+package com.hyuns.cafit.presentation.beverage;
+
+import com.hyuns.cafit.application.beverage.PresetBeverageService;
+import com.hyuns.cafit.application.beverage.dto.BeverageCategoryResponse;
+import com.hyuns.cafit.application.beverage.dto.PresetBeverageResponse;
+import com.hyuns.cafit.presentation.CommonControllerSliceTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = BeverageController.class)
+class BeverageControllerTest extends CommonControllerSliceTestSupport {
+
+    @MockBean
+    private PresetBeverageService presetBeverageService;
+
+    @Test
+    void 전체_음료_목록을_조회한다() throws Exception {
+        // given
+        PresetBeverageResponse beverage = new PresetBeverageResponse(
+            1L, "아메리카노", "스타벅스", "아메리카노", 355, 150.0, "스타벅스 아메리카노"
+        );
+        given(presetBeverageService.getAllBeverages()).willReturn(List.of(beverage));
+
+        // when & then
+        mockMvc.perform(get("/api/beverages")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(1L))
+            .andExpect(jsonPath("$[0].name").value("아메리카노"))
+            .andExpect(jsonPath("$[0].brandName").value("스타벅스"));
+    }
+
+    @Test
+    void 키워드로_음료를_검색한다() throws Exception {
+        // given
+        PresetBeverageResponse beverage = new PresetBeverageResponse(
+            1L, "아메리카노", "스타벅스", "아메리카노", 355, 150.0, "스타벅스 아메리카노"
+        );
+        given(presetBeverageService.searchBeverages("아메리카노")).willReturn(List.of(beverage));
+
+        // when & then
+        mockMvc.perform(get("/api/beverages")
+                .session(loginSession())
+                .param("keyword", "아메리카노"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].name").value("아메리카노"));
+    }
+
+    @Test
+    void 카테고리_목록을_조회한다() throws Exception {
+        // given
+        BeverageCategoryResponse category = new BeverageCategoryResponse(
+            "AMERICANO", "아메리카노", 34.0, 355, 121
+        );
+        given(presetBeverageService.getAllCategories()).willReturn(List.of(category));
+
+        // when & then
+        mockMvc.perform(get("/api/beverages/categories")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].code").value("AMERICANO"))
+            .andExpect(jsonPath("$[0].displayName").value("아메리카노"));
+    }
+}

--- a/src/test/java/com/hyuns/cafit/presentation/beverage/CustomBeverageControllerTest.java
+++ b/src/test/java/com/hyuns/cafit/presentation/beverage/CustomBeverageControllerTest.java
@@ -1,0 +1,139 @@
+package com.hyuns.cafit.presentation.beverage;
+
+import com.hyuns.cafit.application.beverage.CustomBeverageService;
+import com.hyuns.cafit.application.beverage.dto.CustomBeverageCreateRequest;
+import com.hyuns.cafit.application.beverage.dto.CustomBeverageResponse;
+import com.hyuns.cafit.application.beverage.dto.CustomBeverageUpdateRequest;
+import com.hyuns.cafit.domain.beverage.BeverageCategory;
+import com.hyuns.cafit.domain.user.User;
+import com.hyuns.cafit.presentation.CommonControllerSliceTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CustomBeverageController.class)
+class CustomBeverageControllerTest extends CommonControllerSliceTestSupport {
+
+    @MockBean
+    private CustomBeverageService customBeverageService;
+
+    @Test
+    void 커스텀_음료_생성_성공시_200을_반환한다() throws Exception {
+        // given
+        CustomBeverageCreateRequest request = new CustomBeverageCreateRequest(
+            "내 커피", BeverageCategory.AMERICANO, 300, 150.0
+        );
+        CustomBeverageResponse response = new CustomBeverageResponse(
+            1L, "내 커피", "아메리카노", 300, 150.0, "내 커피"
+        );
+        given(customBeverageService.createCustomBeverage(any(User.class), any(CustomBeverageCreateRequest.class)))
+            .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/beverages/custom")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1L))
+            .andExpect(jsonPath("$.name").value("내 커피"));
+    }
+
+    @Test
+    void 커스텀_음료_생성시_이름이_비어있으면_400을_반환한다() throws Exception {
+        // given
+        CustomBeverageCreateRequest request = new CustomBeverageCreateRequest(
+            "", BeverageCategory.AMERICANO, 300, 150.0
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/beverages/custom")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 커스텀_음료_생성시_용량이_0이면_400을_반환한다() throws Exception {
+        // given
+        CustomBeverageCreateRequest request = new CustomBeverageCreateRequest(
+            "내 커피", BeverageCategory.AMERICANO, 0, 150.0
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/beverages/custom")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 내_커스텀_음료_목록을_조회한다() throws Exception {
+        // given
+        CustomBeverageResponse response = new CustomBeverageResponse(
+            1L, "내 커피", "아메리카노", 300, 150.0, "내 커피"
+        );
+        given(customBeverageService.getMyCustomBeverages(any(User.class)))
+            .willReturn(List.of(response));
+
+        // when & then
+        mockMvc.perform(get("/api/beverages/custom")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(1L))
+            .andExpect(jsonPath("$[0].name").value("내 커피"));
+    }
+
+    @Test
+    void 커스텀_음료_수정_성공시_200을_반환한다() throws Exception {
+        // given
+        CustomBeverageUpdateRequest request = new CustomBeverageUpdateRequest("수정 커피", 400, 200.0);
+        CustomBeverageResponse response = new CustomBeverageResponse(
+            1L, "수정 커피", "아메리카노", 400, 200.0, "수정 커피"
+        );
+        given(customBeverageService.updateCustomBeverage(eq(1L), any(User.class), any(CustomBeverageUpdateRequest.class)))
+            .willReturn(response);
+
+        // when & then
+        mockMvc.perform(put("/api/beverages/custom/1")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.name").value("수정 커피"));
+    }
+
+    @Test
+    void 커스텀_음료_삭제_성공시_204를_반환한다() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/beverages/custom/1")
+                .session(loginSession()))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void 세션이_없으면_401을_반환한다() throws Exception {
+        // given
+        CustomBeverageCreateRequest request = new CustomBeverageCreateRequest(
+            "내 커피", BeverageCategory.AMERICANO, 300, 150.0
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/beverages/custom")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/hyuns/cafit/presentation/caffeine/CaffeineCheckControllerTest.java
+++ b/src/test/java/com/hyuns/cafit/presentation/caffeine/CaffeineCheckControllerTest.java
@@ -1,0 +1,91 @@
+package com.hyuns.cafit.presentation.caffeine;
+
+import com.hyuns.cafit.application.caffeine.CaffeineCheckFacade;
+import com.hyuns.cafit.application.beverage.dto.BeverageInfo;
+import com.hyuns.cafit.application.caffeine.dto.*;
+import com.hyuns.cafit.domain.user.User;
+import com.hyuns.cafit.presentation.CommonControllerSliceTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CaffeineCheckController.class)
+class CaffeineCheckControllerTest extends CommonControllerSliceTestSupport {
+
+    @MockBean
+    private CaffeineCheckFacade caffeineCheckFacade;
+
+    @Test
+    void 현재_카페인_상태를_조회한다() throws Exception {
+        // given
+        CaffeineStatus caffeineStatus = new CaffeineStatus(100.0, 30.0, 200.0, 8.0);
+        UserCaffeineSettings settings = new UserCaffeineSettings(400.0, 50.0, 5.0, LocalTime.of(23, 0));
+        CurrentCaffeineResponse response = new CurrentCaffeineResponse(
+            caffeineStatus, settings, DrinkRecommendation.SAFE
+        );
+        given(caffeineCheckFacade.getCurrentStatus(any(User.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/caffeine/status")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status.currentMg").value(100.0))
+            .andExpect(jsonPath("$.recommendation").value("SAFE"));
+    }
+
+    @Test
+    void 프리셋_음료_체크_성공시_200을_반환한다() throws Exception {
+        // given
+        CaffeineStatus before = new CaffeineStatus(100.0, 30.0, 200.0, 8.0);
+        CaffeineStatus after = new CaffeineStatus(250.0, 75.0, 350.0, 8.0);
+        UserCaffeineSettings settings = new UserCaffeineSettings(400.0, 50.0, 5.0, LocalTime.of(23, 0));
+        BeverageInfo beverageInfo = new BeverageInfo("스타벅스 아메리카노", 150.0);
+        DrinkCheckResponse response = new DrinkCheckResponse(
+            beverageInfo, before, after, settings, DrinkRecommendation.WARNING, true
+        );
+        given(caffeineCheckFacade.checkPresetBeverage(any(User.class), eq(1L))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/caffeine/check/preset/1")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.beverage.name").value("스타벅스 아메리카노"))
+            .andExpect(jsonPath("$.isSafe").value(true));
+    }
+
+    @Test
+    void 커스텀_음료_체크_성공시_200을_반환한다() throws Exception {
+        // given
+        CaffeineStatus before = new CaffeineStatus(100.0, 30.0, 200.0, 8.0);
+        CaffeineStatus after = new CaffeineStatus(250.0, 75.0, 350.0, 8.0);
+        UserCaffeineSettings settings = new UserCaffeineSettings(400.0, 50.0, 5.0, LocalTime.of(23, 0));
+        BeverageInfo beverageInfo = new BeverageInfo("내 커피", 150.0);
+        DrinkCheckResponse response = new DrinkCheckResponse(
+            beverageInfo, before, after, settings, DrinkRecommendation.SAFE, true
+        );
+        given(caffeineCheckFacade.checkCustomBeverage(any(User.class), eq(1L))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/caffeine/check/custom/1")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.beverage.name").value("내 커피"));
+    }
+
+    @Test
+    void 세션이_없으면_401을_반환한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/caffeine/status"))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/hyuns/cafit/presentation/favorite/FavoriteBeverageControllerTest.java
+++ b/src/test/java/com/hyuns/cafit/presentation/favorite/FavoriteBeverageControllerTest.java
@@ -1,0 +1,137 @@
+package com.hyuns.cafit.presentation.favorite;
+
+import com.hyuns.cafit.application.favorite.FavoriteBeverageFacade;
+import com.hyuns.cafit.application.favorite.dto.FavoriteBeverageResponse;
+import com.hyuns.cafit.application.favorite.dto.FavoriteCreateRequest;
+import com.hyuns.cafit.application.favorite.dto.FavoriteOrderUpdateRequest;
+import com.hyuns.cafit.domain.beverage.BeverageType;
+import com.hyuns.cafit.domain.user.User;
+import com.hyuns.cafit.presentation.CommonControllerSliceTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = FavoriteBeverageController.class)
+class FavoriteBeverageControllerTest extends CommonControllerSliceTestSupport {
+
+    @MockBean
+    private FavoriteBeverageFacade favoriteBeverageFacade;
+
+    @Test
+    void 즐겨찾기_추가_성공시_200을_반환한다() throws Exception {
+        // given
+        FavoriteCreateRequest request = new FavoriteCreateRequest(BeverageType.PRESET, 1L);
+        FavoriteBeverageResponse response = new FavoriteBeverageResponse(
+            1L, BeverageType.PRESET, 1L, "아메리카노", "스타벅스", "아메리카노", 355, 150.0, 1
+        );
+        given(favoriteBeverageFacade.addFavorite(any(User.class), any(FavoriteCreateRequest.class)))
+            .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/favorites")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1L))
+            .andExpect(jsonPath("$.name").value("아메리카노"))
+            .andExpect(jsonPath("$.type").value("PRESET"));
+    }
+
+    @Test
+    void 즐겨찾기_추가시_타입이_없으면_400을_반환한다() throws Exception {
+        // given
+        FavoriteCreateRequest request = new FavoriteCreateRequest(null, 1L);
+
+        // when & then
+        mockMvc.perform(post("/api/favorites")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 즐겨찾기_추가시_음료ID가_없으면_400을_반환한다() throws Exception {
+        // given
+        FavoriteCreateRequest request = new FavoriteCreateRequest(BeverageType.PRESET, null);
+
+        // when & then
+        mockMvc.perform(post("/api/favorites")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 즐겨찾기_목록을_조회한다() throws Exception {
+        // given
+        FavoriteBeverageResponse response = new FavoriteBeverageResponse(
+            1L, BeverageType.PRESET, 1L, "아메리카노", "스타벅스", "아메리카노", 355, 150.0, 1
+        );
+        given(favoriteBeverageFacade.getFavorites(any(User.class))).willReturn(List.of(response));
+
+        // when & then
+        mockMvc.perform(get("/api/favorites")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(1L))
+            .andExpect(jsonPath("$[0].name").value("아메리카노"));
+    }
+
+    @Test
+    void 즐겨찾기_삭제_성공시_204를_반환한다() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/favorites/1")
+                .session(loginSession()))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void 즐겨찾기_순서_변경_성공시_200을_반환한다() throws Exception {
+        // given
+        FavoriteOrderUpdateRequest request = new FavoriteOrderUpdateRequest(List.of(3L, 1L, 2L));
+
+        // when & then
+        mockMvc.perform(put("/api/favorites/order")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void 즐겨찾기_순서_변경시_목록이_비어있으면_400을_반환한다() throws Exception {
+        // given
+        FavoriteOrderUpdateRequest request = new FavoriteOrderUpdateRequest(List.of());
+
+        // when & then
+        mockMvc.perform(put("/api/favorites/order")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 세션이_없으면_401을_반환한다() throws Exception {
+        // given
+        FavoriteCreateRequest request = new FavoriteCreateRequest(BeverageType.PRESET, 1L);
+
+        // when & then
+        mockMvc.perform(post("/api/favorites")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/hyuns/cafit/presentation/intake/CaffeineIntakeControllerTest.java
+++ b/src/test/java/com/hyuns/cafit/presentation/intake/CaffeineIntakeControllerTest.java
@@ -1,0 +1,125 @@
+package com.hyuns.cafit.presentation.intake;
+
+import com.hyuns.cafit.application.intake.CaffeineIntakeService;
+import com.hyuns.cafit.application.intake.dto.CaffeineIntakeCreateRequest;
+import com.hyuns.cafit.application.intake.dto.CaffeineIntakeResponse;
+import com.hyuns.cafit.domain.beverage.BeverageType;
+import com.hyuns.cafit.domain.user.User;
+import com.hyuns.cafit.presentation.CommonControllerSliceTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CaffeineIntakeController.class)
+class CaffeineIntakeControllerTest extends CommonControllerSliceTestSupport {
+
+    @MockBean
+    private CaffeineIntakeService caffeineIntakeService;
+
+    @Test
+    void 프리셋_음료_섭취_기록_성공시_200을_반환한다() throws Exception {
+        // given
+        LocalDateTime consumedAt = LocalDateTime.of(2026, 3, 31, 9, 0);
+        CaffeineIntakeCreateRequest request = new CaffeineIntakeCreateRequest(consumedAt);
+        CaffeineIntakeResponse response = new CaffeineIntakeResponse(
+            1L, "아메리카노", "스타벅스", "아메리카노", 355, 150.0,
+            consumedAt, "스타벅스 아메리카노", BeverageType.PRESET, 1L
+        );
+        given(caffeineIntakeService.recordPresetIntake(any(User.class), eq(1L), any(CaffeineIntakeCreateRequest.class)))
+            .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/intakes/preset/1")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1L))
+            .andExpect(jsonPath("$.beverageName").value("아메리카노"))
+            .andExpect(jsonPath("$.sourceType").value("PRESET"));
+    }
+
+    @Test
+    void 커스텀_음료_섭취_기록_성공시_200을_반환한다() throws Exception {
+        // given
+        LocalDateTime consumedAt = LocalDateTime.of(2026, 3, 31, 14, 0);
+        CaffeineIntakeCreateRequest request = new CaffeineIntakeCreateRequest(consumedAt);
+        CaffeineIntakeResponse response = new CaffeineIntakeResponse(
+            2L, "내 커피", null, "아메리카노", 300, 120.0,
+            consumedAt, "내 커피", BeverageType.CUSTOM, 1L
+        );
+        given(caffeineIntakeService.recordCustomIntake(any(User.class), eq(1L), any(CaffeineIntakeCreateRequest.class)))
+            .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/intakes/custom/1")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(2L))
+            .andExpect(jsonPath("$.sourceType").value("CUSTOM"));
+    }
+
+    @Test
+    void 섭취_기록시_섭취시간이_없으면_400을_반환한다() throws Exception {
+        // given
+        CaffeineIntakeCreateRequest request = new CaffeineIntakeCreateRequest(null);
+
+        // when & then
+        mockMvc.perform(post("/api/intakes/preset/1")
+                .session(loginSession())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 오늘_섭취_기록을_조회한다() throws Exception {
+        // given
+        LocalDateTime consumedAt = LocalDateTime.of(2026, 3, 31, 9, 0);
+        CaffeineIntakeResponse response = new CaffeineIntakeResponse(
+            1L, "아메리카노", "스타벅스", "아메리카노", 355, 150.0,
+            consumedAt, "스타벅스 아메리카노", BeverageType.PRESET, 1L
+        );
+        given(caffeineIntakeService.getTodayIntakes(any(User.class))).willReturn(List.of(response));
+
+        // when & then
+        mockMvc.perform(get("/api/intakes/today")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(1L))
+            .andExpect(jsonPath("$[0].beverageName").value("아메리카노"));
+    }
+
+    @Test
+    void 섭취_기록_삭제_성공시_204를_반환한다() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/intakes/1")
+                .session(loginSession()))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void 세션이_없으면_401을_반환한다() throws Exception {
+        // given
+        CaffeineIntakeCreateRequest request = new CaffeineIntakeCreateRequest(LocalDateTime.now());
+
+        // when & then
+        mockMvc.perform(post("/api/intakes/preset/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/hyuns/cafit/presentation/statistics/CaffeineStatisticsControllerTest.java
+++ b/src/test/java/com/hyuns/cafit/presentation/statistics/CaffeineStatisticsControllerTest.java
@@ -1,0 +1,106 @@
+package com.hyuns.cafit.presentation.statistics;
+
+import com.hyuns.cafit.application.statistics.CaffeineStatisticsService;
+import com.hyuns.cafit.application.statistics.dto.*;
+import com.hyuns.cafit.domain.user.User;
+import com.hyuns.cafit.presentation.CommonControllerSliceTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CaffeineStatisticsController.class)
+class CaffeineStatisticsControllerTest extends CommonControllerSliceTestSupport {
+
+    @MockBean
+    private CaffeineStatisticsService caffeineStatisticsService;
+
+    @Test
+    void 타임라인을_조회한다() throws Exception {
+        // given
+        TimelineDataPoint dataPoint = new TimelineDataPoint(LocalDateTime.of(2026, 3, 31, 9, 0), 150.0);
+        CaffeineTimelineResponse response = new CaffeineTimelineResponse(
+            List.of(dataPoint),
+            LocalDateTime.of(2026, 3, 31, 15, 0),
+            LocalDateTime.of(2026, 3, 31, 23, 0),
+            50.0
+        );
+        given(caffeineStatisticsService.getTimeline(any(User.class), eq(12))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/statistics/timeline")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.dataPoints[0].caffeineMg").value(150.0))
+            .andExpect(jsonPath("$.targetSleepCaffeine").value(50.0));
+    }
+
+    @Test
+    void 타임라인_조회시_시간을_지정할_수_있다() throws Exception {
+        // given
+        CaffeineTimelineResponse response = new CaffeineTimelineResponse(
+            List.of(),
+            LocalDateTime.of(2026, 3, 31, 15, 0),
+            LocalDateTime.of(2026, 3, 31, 23, 0),
+            50.0
+        );
+        given(caffeineStatisticsService.getTimeline(any(User.class), eq(24))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/statistics/timeline")
+                .session(loginSession())
+                .param("hours", "24"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void 일별_통계를_조회한다() throws Exception {
+        // given
+        StatisticsPeriod period = new StatisticsPeriod(LocalDate.of(2026, 3, 25), LocalDate.of(2026, 3, 31));
+        DailyStat dailyStat = new DailyStat(LocalDate.of(2026, 3, 31), 300.0, 3);
+        DailyStatisticsResponse response = new DailyStatisticsResponse(
+            period, List.of(dailyStat), 250.0, 400.0
+        );
+        given(caffeineStatisticsService.getDailyStatistics(any(User.class), eq(7))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/statistics/daily")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.periodAverage").value(250.0))
+            .andExpect(jsonPath("$.dailyLimit").value(400.0))
+            .andExpect(jsonPath("$.dailyStats[0].totalCaffeineMg").value(300.0));
+    }
+
+    @Test
+    void 인기_음료를_조회한다() throws Exception {
+        // given
+        TopBeverageStat stat = new TopBeverageStat("아메리카노", "스타벅스", 355, 5);
+        given(caffeineStatisticsService.getTopBeverages(any(User.class), eq(7)))
+            .willReturn(List.of(stat));
+
+        // when & then
+        mockMvc.perform(get("/api/statistics/top-beverages")
+                .session(loginSession()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].beverageName").value("아메리카노"))
+            .andExpect(jsonPath("$[0].count").value(5));
+    }
+
+    @Test
+    void 세션이_없으면_401을_반환한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/statistics/timeline"))
+            .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
# 관련 이슈 번호
- Closes #14

## 이 PR을 통해 해결하려는 문제가 무엇인가요?

리팩토링된 Controller 계층에 대한 슬라이스 테스트가 없어서 HTTP 요청/응답, 검증, 인증 처리의 정상 동작을 보장할 수 없었습니다.

## 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

- CommonControllerSliceTestSupport 베이스 클래스 생성 (@WebMvcTest + SecurityConfig/LoginUserArgumentResolver Import)
- AuthControllerTest: 회원가입, 로그인, 로그아웃, 현재 사용자 조회 (8개)
- BeverageControllerTest: 프리셋 음료 목록, 키워드 검색, 카테고리 조회 (3개)
- CustomBeverageControllerTest: 커스텀 음료 CRUD (7개)
- CaffeineCheckControllerTest: 카페인 상태 조회, 프리셋/커스텀 체크 (4개)
- FavoriteBeverageControllerTest: 즐겨찾기 추가, 조회, 삭제, 순서 변경 (8개)
- CaffeineIntakeControllerTest: 섭취 기록, 조회, 삭제 (6개)
- CaffeineStatisticsControllerTest: 타임라인, 일별 통계, 인기 음료 (5개)

## 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

- @WebMvcTest에서 SecurityConfig를 명시적으로 Import해야 CSRF 403이 발생하지 않음
- LoginFilter가 FilterRegistrationBean으로 등록되어 있어도 MockMvc에서 동작하므로, @Login이 없는 BeverageController도 세션 필요
- @WithLoginUser는 RequestContextHolder 기반이라 MockMvc에서 동작하지 않아 loginSession() 헬퍼로 대체